### PR TITLE
Fix minor issue with manual HTTP code sample

### DIFF
--- a/cynic-book/src/manual-http-requests.md
+++ b/cynic-book/src/manual-http-requests.md
@@ -26,7 +26,7 @@ let response = reqwest::blocking::Client::new()
     .send()
     .unwrap();
 
-let all_films_result = response.json::<GraphQlResponse<AllFilmsQuery>>.unwrap();
+let all_films_result = response.json::<GraphQlResponse<AllFilmsQuery>>().unwrap();
 ```
 
 Now you can do whatever you want with the result.


### PR DESCRIPTION
fix manual HTTP code sample

#### Why are we making this change?

This is a very minor change but it might throw users who are less familiar with reqwest for a loop

#### What effects does this change have?

The json member in reqwest's response is a function and needs to be called, not accessed.
